### PR TITLE
Git perspective as default perspective (Issue #1)

### DIFF
--- a/com.eclipsesource.megit.product.feature/build.properties
+++ b/com.eclipsesource.megit.product.feature/build.properties
@@ -1,1 +1,2 @@
 bin.includes = feature.xml
+root=file:plugin_customization.ini

--- a/com.eclipsesource.megit.product.feature/plugin_customization.ini
+++ b/com.eclipsesource.megit.product.feature/plugin_customization.ini
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+org.eclipse.core.resources/encoding=UTF-8
+org.eclipse.ui/defaultPerspectiveId=org.eclipse.egit.ui.GitRepositoryExploring
+org.eclipse.ui/SHOW_MEMORY_MONITOR=true
+org.eclipse.ui/showIntro=false

--- a/com.eclipsesource.megit.product/megit.product
+++ b/com.eclipsesource.megit.product/megit.product
@@ -8,6 +8,9 @@
    </configIni>
 
    <launcherArgs>
+      <programArgs>-pluginCustomization plugin_customization.ini
+-cssTheme org.eclipse.e4.ui.css.theme.e4_dark
+      </programArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
    </launcherArgs>


### PR DESCRIPTION
Hi,

a small improvement mentioned in #1. Following things changed:

1. Git as default perspective
2. Removed default eclipse welcome page
3. Dark theme as default 

Feel free to modify it as you consider best. 

Here's a screen how it looks like after start:
![workspace - Eclipse Platform _031](https://user-images.githubusercontent.com/20700104/105165121-387c2400-5b16-11eb-9874-11f875886d90.png)
