### PR TITLE
include JRE in bundles + upgrade tycho v4.0.4

### DIFF
--- a/com.eclipsesource.megit.parent/.settings/org.eclipse.core.resources.prefs
+++ b/com.eclipsesource.megit.parent/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/com.eclipsesource.megit.parent/pom.xml
+++ b/com.eclipsesource.megit.parent/pom.xml
@@ -10,15 +10,23 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>2.7.5</tycho-version>
+		<tycho-version>4.0.4</tycho-version>
 		<tycho-extras-version>2.7.5</tycho-extras-version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.release>17</maven.compiler.release>
-
 		<mav-checkstyle-version>3.0.0</mav-checkstyle-version>
 		<checkstyle-version>8.8</checkstyle-version>
+
+		<maven.compiler.release>17</maven.compiler.release>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
+   <repositories>
+      <repository>
+         <id>justj</id>
+         <url>https://download.eclipse.org/justj/jres/17/updates/release/latest</url>
+         <layout>p2</layout>
+      </repository>
+   </repositories>
+   
 	<pluginRepositories>
 		<pluginRepository>
 			<id>eclipse-maven-releases</id>
@@ -65,10 +73,8 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
-					<resolver>p2</resolver>
 					<pomDependencies>consider</pomDependencies>
-					<allowConflictingDependencies>true</allowConflictingDependencies>
-					<includePackedArtifacts>true</includePackedArtifacts>
+					<executionEnvironment>org.eclipse.justj.openjdk.hotspot.jre.full-17</executionEnvironment>
 					<environments>
 						<environment>
 							<os>win32</os>
@@ -115,11 +121,13 @@
 						<artifactId>tycho-buildtimestamp-jgit</artifactId>
 						<version>${tycho-extras-version}</version>
 					</dependency>
+					<!--
 					<dependency>
 						<groupId>org.eclipse.tycho.extras</groupId>
 						<artifactId>tycho-sourceref-jgit</artifactId>
 						<version>${tycho-extras-version}</version>
 					</dependency>
+					-->
 				</dependencies>
 				<configuration>
 					<format>yyyyMMdd-HHmm</format>
@@ -127,8 +135,8 @@
 					<sourceReferences>
 						<generate>true</generate>
 					</sourceReferences>
-					 -->
 					<timestampProvider>jgit</timestampProvider>
+					 -->
 					<jgit.ignore>
 						pom.xml
 					</jgit.ignore>
@@ -159,7 +167,6 @@
 				<version>${tycho-version}</version>
 				<configuration>
 					<useProjectSettings>true</useProjectSettings>
-					<logEnabled>true</logEnabled>
 					<logDirectory>${project.build.directory}/logfiles</logDirectory>
 					<log>xml</log>
 					<!-- <useJDK>BREE</useJDK> -->

--- a/com.eclipsesource.megit.plugin/.settings/org.eclipse.core.resources.prefs
+++ b/com.eclipsesource.megit.plugin/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/com.eclipsesource.megit.plugin/.settings/org.eclipse.jdt.core.prefs
+++ b/com.eclipsesource.megit.plugin/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=17

--- a/com.eclipsesource.megit.product.feature/.settings/org.eclipse.core.resources.prefs
+++ b/com.eclipsesource.megit.product.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/com.eclipsesource.megit.product/.settings/org.eclipse.core.resources.prefs
+++ b/com.eclipsesource.megit.product/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/com.eclipsesource.megit.product/megit.product
+++ b/com.eclipsesource.megit.product/megit.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Minimal EGit" uid="com.eclipsesource.megit" id="com.eclipsesource.megit.plugin.megit" application="org.eclipse.ui.ide.workbench" version="1.0.0.qualifier" useFeatures="true" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Minimal EGit" uid="com.eclipsesource.megit" id="com.eclipsesource.megit.plugin.megit" application="org.eclipse.ui.ide.workbench" version="1.0.0.qualifier" type="mixed" includeLaunchers="true" autoIncludeRequirements="true">
 
    <configIni use="default">
    </configIni>
@@ -309,6 +309,7 @@ version(s), and exceptions or additional permissions here}.&quot;
    </license>
 
    <plugins>
+      <plugin id="org.eclipse.justj.openjdk.hotspot.jre.full"/>
    </plugins>
 
    <features>

--- a/com.eclipsesource.megit.target/.settings/org.eclipse.core.resources.prefs
+++ b/com.eclipsesource.megit.target/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/com.eclipsesource.megit.target/com.eclipsesource.megit.target.target
+++ b/com.eclipsesource.megit.target/com.eclipsesource.megit.target.target
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
-<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="MeGit Target" sequenceNumber="1698865063">
+<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl --><target name="MeGit Target" sequenceNumber="1698865063">
   <locations>
-    <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+    <location includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.jgit.feature.group" version="6.7.0.202309050840-r"/>
       <unit id="org.eclipse.jgit.gpg.bc.feature.group" version="6.7.0.202309050840-r"/>
       <unit id="org.eclipse.jgit.ssh.jsch.feature.group" version="6.7.0.202309050840-r"/>
@@ -48,7 +47,7 @@
       <unit id="com.sun.jna.platform" version="5.13.0"/>
       <repository location="https://download.eclipse.org/releases/2023-09/"/>
     </location>
-    <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+    <location includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
       <unit id="com.google.guava" version="30.1.0.v20221112-0806"/>
       <unit id="com.google.gson" version="2.10.1.v20230109-0753"/>
       <unit id="org.bouncycastle.bcpg" version="1.72.0.v20221013-1810"/>
@@ -63,15 +62,24 @@
       <unit id="org.objectweb.asm.analysis" version="9.4.0.v20221107-1714"/>
       <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230531010532/repository"/>
     </location>
-    <location includeDependencyDepth="infinite" includeDependencyScopes="compile,test" includeSource="true" missingManifest="generate" type="Maven" label="MavenDependencies">
-    <dependencies>
-    	<dependency>
-    		<groupId>commons-codec</groupId>
-    		<artifactId>commons-codec</artifactId>
-    		<version>1.15</version>
-    		<type>jar</type>
-    	</dependency>
-    </dependencies>
-    </location>
+	  <location includeDependencyDepth="infinite" includeDependencyScopes="compile,test" includeSource="true" label="MavenDependencies" missingManifest="generate" type="Maven">
+		  <dependencies>
+			  <dependency>
+				  <groupId>commons-codec</groupId>
+				  <artifactId>commons-codec</artifactId>
+				  <version>1.15</version>
+				  <type>jar</type>
+			  </dependency>
+		  </dependencies>
+	  </location>
+	  <location includeAllPlatforms="true" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
+		  <repository location="https://download.eclipse.org/justj/jres/17/updates/release/latest"/>
+		  <unit id="org.eclipse.justj.openjdk.hotspot.jre.base.feature.group" version="17.0.9.v20231028-0858"/>
+		  <unit id="org.eclipse.justj.openjdk.hotspot.jre.base.stripped.feature.group" version="17.0.9.v20231028-0858"/>
+		  <unit id="org.eclipse.justj.openjdk.hotspot.jre.full.feature.group" version="17.0.9.v20231028-0858"/>
+		  <unit id="org.eclipse.justj.openjdk.hotspot.jre.full.stripped.feature.group" version="17.0.9.v20231028-0858"/>
+		  <unit id="org.eclipse.justj.openjdk.hotspot.jre.minimal.feature.group" version="17.0.9.v20231028-0858"/>
+		  <unit id="org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped.feature.group" version="17.0.9.v20231028-0858"/>
+	  </location>
   </locations>
 </target>


### PR DESCRIPTION
include JRE in bundles + upgrade tycho v4.0.4

I had to comment`"<timestampProvider>jgit</timestampProvider>"` in `com.eclipsesource.megit.parent\pom.xml`to have it to compile
Please check it
