### PR TITLE
Upgrade to 2024-06

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,6 @@ The runnable product will be available in `com.eclipsesource.megit.product/targe
   - Add Git LFS support
 - 0.6.0 Update to Eclipse EGit 2023-12
   - Package JVM with product (#42)
+- 0.7.0 Update to Eclipse EGit 2024-06
+  - Adds org.eclipse.tm4e for generic syntax highlighting
+

--- a/com.eclipsesource.megit.parent/megit.target
+++ b/com.eclipsesource.megit.parent/megit.target
@@ -1,140 +1,167 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="MeGit Target" sequenceNumber="1706818887">
+<target name="MeGit Target" sequenceNumber="1720724565">
   <locations>
     <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.jgit.feature.group" version="6.8.0.202311291450-r"/>
-      <unit id="org.eclipse.jgit.gpg.bc.feature.group" version="6.8.0.202311291450-r"/>
-      <unit id="org.eclipse.jgit.ssh.jsch.feature.group" version="6.8.0.202311291450-r"/>
-      <unit id="org.eclipse.jgit.http.apache.feature.group" version="6.8.0.202311291450-r"/>
-      <unit id="org.eclipse.jgit.ssh.apache.feature.group" version="6.8.0.202311291450-r"/>
-      <unit id="org.eclipse.jgit.lfs.feature.group" version="6.8.0.202311291450-r"/>
-      <unit id="org.eclipse.egit.feature.group" version="6.8.0.202311291450-r"/>
-      <unit id="org.eclipse.egit.gitflow.feature.feature.group" version="6.8.0.202311291450-r"/>
-      <unit id="org.eclipse.emf.sdk.feature.group" version="2.36.0.v20231107-0612"/>
+      <unit id="org.eclipse.equinox.http.service.api" version="1.2.2.v20231218-2126"/>
+      <unit id="org.eclipse.jgit.feature.group" version="6.10.0.202406032230-r"/>
+      <unit id="org.eclipse.jgit.gpg.bc.feature.group" version="6.10.0.202406032230-r"/>
+      <unit id="org.eclipse.jgit.ssh.jsch.feature.group" version="6.10.0.202406032230-r"/>
+      <unit id="org.eclipse.jgit.http.apache.feature.group" version="6.10.0.202406032230-r"/>
+      <unit id="org.eclipse.jgit.ssh.apache.feature.group" version="6.10.0.202406032230-r"/>
+      <unit id="org.eclipse.jgit.lfs.feature.group" version="6.10.0.202406032230-r"/>
+      <unit id="org.eclipse.egit.feature.group" version="6.10.0.202406032230-r"/>
+      <unit id="org.eclipse.egit.gitflow.feature.feature.group" version="6.10.0.202406032230-r"/>
+      <unit id="org.eclipse.emf.sdk.feature.group" version="2.38.0.v20240314-1003"/>
       <unit id="org.eclipse.emf.transaction.feature.group" version="1.13.0.202208110935"/>
       <unit id="org.eclipse.emf.validation.feature.group" version="1.13.3.202305230712"/>
-      <unit id="org.eclipse.platform.ide" version="4.30.0.I20231201-0110"/>
-      <unit id="org.eclipse.equinox.p2.rcp.feature.feature.group" version="1.4.2200.v20231112-1314"/>
-      <unit id="org.eclipse.equinox.sdk.feature.group" version="3.23.1000.v20231114-0937"/>
-      <unit id="org.eclipse.equinox.core.feature.feature.group" version="1.14.200.v20231110-1900"/>
-      <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.3.200.v20231104-1339"/>
-      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.2300.v20231106-1826"/>
+      <unit id="org.eclipse.platform.ide" version="4.32.0.I20240601-0610"/>
+      <unit id="org.eclipse.equinox.p2.rcp.feature.feature.group" version="1.4.2400.v20240515-1919"/>
+      <unit id="org.eclipse.equinox.sdk.feature.group" version="3.23.1200.v20240524-2033"/>
+      <unit id="org.eclipse.equinox.core.feature.feature.group" version="1.15.100.v20240524-2011"/>
+      <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.3.400.v20240417-0757"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.2500.v20240513-1750"/>
       <unit id="org.eclipse.ecf.core.feature.feature.group" version="1.6.2.v20231021-2127"/>
       <unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="1.1.501.v20230507-1921"/>
       <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.14.1900.v20230715-1945"/>
       <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" version="1.1.702.v20231114-1017"/>
       <unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.402.v20231021-2127"/>
-      <unit id="org.eclipse.jdt.core.compiler.batch" version="3.36.0.v20231114-0937"/>
-      <unit id="org.eclipse.jdt.core" version="3.36.0.v20231115-1055"/>
+      <unit id="org.eclipse.jdt.core.compiler.batch" version="3.38.0.v20240524-2033"/>
+      <unit id="org.eclipse.jdt.core" version="3.38.0.v20240528-0618"/>
       <unit id="net.i2p.crypto.eddsa" version="0.3.0"/>
       <unit id="org.apache.commons.io" version="2.8.0.v20210415-0900"/>
       <unit id="org.apache.httpcomponents.httpcore" version="4.4.16.v20221207-1049"/>
       <unit id="org.apache.httpcomponents.httpclient" version="4.5.14"/>
-      <unit id="org.apache.sshd.sftp" version="2.11.0"/>
-      <unit id="org.apache.sshd.osgi" version="2.11.0"/>
-      <unit id="org.apache.lucene.core" version="9.8.0.v20230929-1030"/>
-      <unit id="org.apache.lucene.analysis-common" version="9.8.0.v20230929-1030"/>
-      <unit id="org.apache.lucene.analysis-smartcn" version="9.8.0.v20230929-1030"/>
-      <unit id="slf4j.api" version="2.0.9"/>
+      <unit id="org.apache.sshd.sftp" version="2.12.1"/>
+      <unit id="org.apache.sshd.osgi" version="2.12.1"/>
+      <unit id="org.apache.lucene.core" version="9.10.0.v20240221-0830"/>
+      <unit id="org.apache.lucene.analysis-common" version="9.10.0.v20240221-0830"/>
+      <unit id="org.apache.lucene.analysis-smartcn" version="9.10.0.v20240221-0830"/>
       <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.7"/>
       <unit id="org.apache.commons.jxpath" version="1.3.0.v200911051830"/>
-      <unit id="com.sun.jna" version="5.13.0.v20230812-1000"/>
-      <unit id="com.sun.jna.platform" version="5.13.0"/>
-      <unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>
+      <unit id="com.sun.jna" version="5.14.0.v20231211-1200"/>
+      <unit id="com.sun.jna.platform" version="5.14.0"/>
       <unit id="jakarta.annotation-api" version="2.1.1"/>
-      <unit id="org.eclipse.jetty.http" version="12.0.3"/>
-      <unit id="org.eclipse.jetty.server" version="12.0.3"/>
-      <unit id="org.eclipse.jetty.session" version="12.0.3"/>
-      <unit id="org.eclipse.jetty.ee8.servlet" version="12.0.3"/>
-      <unit id="org.eclipse.jetty.ee8.security" version="12.0.3"/>
+      <unit id="org.eclipse.jetty.http" version="12.0.9"/>
+      <unit id="org.eclipse.jetty.server" version="12.0.9"/>
+      <unit id="org.eclipse.jetty.session" version="12.0.9"/>
+      <unit id="org.eclipse.jetty.ee8.servlet" version="12.0.9"/>
+      <unit id="org.eclipse.jetty.ee8.security" version="12.0.9"/>
       <unit id="com.sun.el.javax.el" version="3.0.4"/>
-      <unit id="org.eclipse.search.core" version="3.16.0.v20230921-0933"/>
-      <unit id="org.objectweb.asm" version="9.6.0"/>
-      <unit id="org.objectweb.asm.commons" version="9.6.0"/>
-      <unit id="org.objectweb.asm.util" version="9.6.0"/>
-      <unit id="org.objectweb.asm.tree" version="9.6.0"/>
-      <unit id="org.objectweb.asm.tree.analysis" version="9.6.0"/>
+      <unit id="org.eclipse.search.core" version="3.16.200.v20240502-1134"/>
+      <unit id="org.objectweb.asm" version="9.7.0"/>
+      <unit id="org.objectweb.asm.commons" version="9.7.0"/>
+      <unit id="org.objectweb.asm.util" version="9.7.0"/>
+      <unit id="org.objectweb.asm.tree" version="9.7.0"/>
+      <unit id="org.objectweb.asm.tree.analysis" version="9.7.0"/>
       <unit id="org.apache.commons.commons-codec" version="1.16.0"/>
-      <repository location="https://download.eclipse.org/releases/2023-12/"/>
+      <unit id="org.apache.commons.commons-compress" version="1.26.2"/>
+      <unit id="org.eclipse.tm4e.feature.feature.group" version="0.12.0.202405210827"/>
+      <unit id="org.eclipse.tm4e.language_pack.feature.feature.group" version="0.12.0.202405210827"/>
+      <unit id="org.eclipse.tm4e.languageconfiguration" version="0.12.0.202405210827"/>
+      <unit id="org.jcodings" version="1.0.58.v20230703-0749"/>
+      <unit id="org.joni" version="2.2.1.v20230703-0749"/>
+      <unit id="org.snakeyaml.engine" version="2.7.0"/>
+      <repository location="https://download.eclipse.org/releases/2024-06/"/>
     </location>
     <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="com.google.guava" version="30.1.0.v20221112-0806"/>
-      <unit id="com.google.gson" version="2.10.1.v20230109-0753"/>
-      <unit id="org.bouncycastle.bcpg" version="1.72.0.v20221013-1810"/>
-      <unit id="org.bouncycastle.bcpkix" version="1.72.0.v20221013-1810"/>
-      <unit id="org.bouncycastle.bcprov" version="1.72.0.v20221013-1810"/>
-      <unit id="org.bouncycastle.bcutil" version="1.72.0.v20221013-1810"/>
-      <unit id="org.objectweb.asm.analysis" version="9.4.0.v20221107-1714"/>
-      <unit id="javaewah" version="1.1.13.v20211029-0839"/>
-      <unit id="org.apache.commons.compress" version="1.22.0.v20221207-1049"/>
+      <unit id="com.google.guava" version="33.2.0.jre"/>
+      <unit id="com.google.gson" version="2.11.0"/>
+      <unit id="bcpg" version="1.78.1"/>
+      <unit id="bcpkix" version="1.78.1"/>
+      <unit id="bcprov" version="1.78.1"/>
+      <unit id="bcutil" version="1.78.1"/>
+      <unit id="com.googlecode.javaewah.JavaEWAH" version="1.2.3"/>
+      <unit id="org.apache.batik.css" version="1.17.0.v20231215-1130"/>
+      <unit id="org.apache.batik.util" version="1.17.0.v20231215-1130"/>
+      <unit id="org.apache.batik.constants" version="1.17.0.v20231215-1130"/>
+      <unit id="org.apache.batik.i18n" version="1.17.0.v20231215-1130"/>
+      <unit id="org.apache.commons.logging" version="1.2.0"/>
+      <unit id="com.ibm.icu" version="75.1.0"/>
+      <unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>
+      <unit id="com.google.inject" version="7.0.0"/>
+      <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-06/"/>
+    </location>
+    <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="javax.inject" version="1.0.0.v20220405-0441"/>
-      <unit id="org.apache.batik.css" version="1.16.0.v20221027-0840"/>
-      <unit id="org.apache.batik.util" version="1.16.0.v20221027-0840"/>
-      <unit id="org.apache.batik.constants" version="1.16.0.v20221027-0840"/>
-      <unit id="org.apache.batik.i18n" version="1.16.0.v20221027-0840"/>
-      <unit id="org.apache.commons.logging" version="1.2.0.v20180409-1502"/>
-      <unit id="com.ibm.icu" version="72.1.0.v20221115-2007"/>
       <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230531010532/repository"/>
     </location>
-    <location includeDependencyDepth="infinite" includeDependencyScopes="compile,test" includeSource="true" missingManifest="generate" type="Maven" label="MavenDependencies">
-    <dependencies>
-    	<dependency>
-    		<groupId>org.eclipse.birt.runtime.3_7_1</groupId>
-    		<artifactId>org.w3c.dom.svg</artifactId>
-    		<version>1.1.0</version>
-    		<type>jar</type>
-    	</dependency>
-    	<dependency>
-    		<groupId>org.eclipse.birt.runtime.3_7_1</groupId>
-    		<artifactId>org.w3c.css.sac</artifactId>
-    		<version>1.3.0</version>
-    		<type>jar</type>
-    	</dependency>
-    	<dependency>
-    		<groupId>org.eclipse.birt.runtime</groupId>
-    		<artifactId>org.w3c.dom.events</artifactId>
-    		<version>3.0.0.draft20060413_v201105210656</version>
-    		<type>jar</type>
-    	</dependency>
-    	<dependency>
-    		<groupId>org.eclipse.birt.runtime.3_7_1</groupId>
-    		<artifactId>org.w3c.dom.smil</artifactId>
-    		<version>1.0.0</version>
-    		<type>jar</type>
-    	</dependency>
-    	<dependency>
-    		<groupId>commons-io</groupId>
-    		<artifactId>commons-io</artifactId>
-    		<version>1.4</version>
-    		<type>jar</type>
-    	</dependency>
-    	<dependency>
-    		<groupId>javax.servlet</groupId>
-    		<artifactId>javax.servlet-api</artifactId>
-    		<version>4.0.1</version>
-    		<type>jar</type>
-    	</dependency>
-    	<dependency>
-    		<groupId>org.glassfish.web</groupId>
-    		<artifactId>javax.servlet.jsp</artifactId>
-    		<version>2.3.4</version>
-    		<type>jar</type>
-    	</dependency>
-    	<dependency>
-    		<groupId>org.eclipse.jetty.ee8</groupId>
-    		<artifactId>jetty-ee8-nested</artifactId>
-    		<version>12.0.5</version>
-    		<type>jar</type>
-    	</dependency>
-    	<dependency>
-    		<groupId>org.mortbay.jasper</groupId>
-    		<artifactId>apache-jsp</artifactId>
-    		<version>9.0.83</version>
-    		<type>jar</type>
-    	</dependency>
-    </dependencies>
+    <location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="MavenDependencies">
+      <dependencies>
+        <dependency>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.service.http.whiteboard</artifactId>
+          <version>1.1.0</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.birt.runtime.3_7_1</groupId>
+          <artifactId>org.w3c.dom.svg</artifactId>
+          <version>1.1.0</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.birt.runtime.3_7_1</groupId>
+          <artifactId>org.w3c.css.sac</artifactId>
+          <version>1.3.0</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.birt.runtime</groupId>
+          <artifactId>org.w3c.dom.events</artifactId>
+          <version>3.0.0.draft20060413_v201105210656</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.birt.runtime.3_7_1</groupId>
+          <artifactId>org.w3c.dom.smil</artifactId>
+          <version>1.0.0</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+          <version>1.4</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>javax.servlet</groupId>
+          <artifactId>javax.servlet-api</artifactId>
+          <version>4.0.1</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.glassfish.web</groupId>
+          <artifactId>javax.servlet.jsp</artifactId>
+          <version>2.3.4</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.jetty.ee8</groupId>
+          <artifactId>jetty-ee8-nested</artifactId>
+          <version>12.0.5</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.mortbay.jasper</groupId>
+          <artifactId>apache-jsp</artifactId>
+          <version>9.0.83</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.eclipse.jetty.ee8</groupId>
+          <artifactId>jetty-ee8-nested</artifactId>
+          <version>12.0.11</version>
+          <type>jar</type>
+        </dependency>
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-simple</artifactId>
+          <version>2.1.0-alpha1</version>
+          <type>jar</type>
+        </dependency>
+      </dependencies>
     </location>
   </locations>
 </target>

--- a/com.eclipsesource.megit.parent/megit.tpd
+++ b/com.eclipsesource.megit.parent/megit.tpd
@@ -1,6 +1,7 @@
 target "MeGit Target"
 with allEnvironments source
-location "https://download.eclipse.org/releases/2023-12/" {
+location "https://download.eclipse.org/releases/2024-06/" {
+	org.eclipse.equinox.http.service.api
 	org.eclipse.jgit.feature.group
 	org.eclipse.jgit.gpg.bc.feature.group
 	org.eclipse.jgit.ssh.jsch.feature.group
@@ -34,12 +35,10 @@ location "https://download.eclipse.org/releases/2023-12/" {
 	org.apache.lucene.core
 	org.apache.lucene.analysis-common
 	org.apache.lucene.analysis-smartcn
-	slf4j.api
 	org.apache.aries.spifly.dynamic.bundle
 	org.apache.commons.jxpath
 	com.sun.jna
 	com.sun.jna.platform
-	jakarta.inject.jakarta.inject-api
 	jakarta.annotation-api
 	org.eclipse.jetty.http
 	org.eclipse.jetty.server
@@ -54,27 +53,42 @@ location "https://download.eclipse.org/releases/2023-12/" {
 	org.objectweb.asm.tree
 	org.objectweb.asm.tree.analysis
 	org.apache.commons.commons-codec
+	org.apache.commons.commons-compress
+	org.eclipse.tm4e.feature.feature.group
+	org.eclipse.tm4e.language_pack.feature.feature.group
+	org.eclipse.tm4e.languageconfiguration
+	org.jcodings
+	org.joni
+	org.snakeyaml.engine
 }
-location "https://download.eclipse.org/tools/orbit/downloads/drops/R20230531010532/repository" {
+location "https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-06/" {
 	com.google.guava
 	com.google.gson
-	org.bouncycastle.bcpg
-	org.bouncycastle.bcpkix
-	org.bouncycastle.bcprov
-	org.bouncycastle.bcutil
-	org.objectweb.asm.analysis
-	javaewah
-	org.apache.commons.compress
-	javax.inject
+	bcpg
+	bcpkix
+	bcprov
+	bcutil
+	com.googlecode.javaewah.JavaEWAH
 	org.apache.batik.css
 	org.apache.batik.util
 	org.apache.batik.constants
 	org.apache.batik.i18n
 	org.apache.commons.logging
 	com.ibm.icu
+	jakarta.inject.jakarta.inject-api
+	com.google.inject
 }
 
-maven MavenDependencies scope=compile,test dependencyDepth=infinite missingManifest=generate includeSources {
+location "https://download.eclipse.org/tools/orbit/downloads/drops/R20230531010532/repository" {
+	javax.inject
+}
+
+maven MavenDependencies scope=compile dependencyDepth=infinite missingManifest=generate includeSources {
+	dependency {
+		groupId="org.osgi"
+		artifactId="org.osgi.service.http.whiteboard"
+		version="1.1.0"
+	}
 	dependency {
 		groupId="org.eclipse.birt.runtime.3_7_1"
 		artifactId="org.w3c.dom.svg"
@@ -119,5 +133,16 @@ maven MavenDependencies scope=compile,test dependencyDepth=infinite missingManif
 		groupId="org.mortbay.jasper"
 		artifactId="apache-jsp"
 		version="9.0.83"
+	}
+	dependency {
+		groupId="org.eclipse.jetty.ee8"
+		artifactId="jetty-ee8-nested"
+		version="12.0.11"
+	}
+	
+	dependency {
+		groupId="org.slf4j"
+		artifactId="slf4j-simple"
+		version="2.1.0-alpha1"
 	}
 }

--- a/com.eclipsesource.megit.parent/pom.xml
+++ b/com.eclipsesource.megit.parent/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.eclipsesource.megit</groupId>
 	<artifactId>com.eclipsesource.megit.parent</artifactId>
-	<version>0.6.0-SNAPSHOT</version>
+	<version>0.7.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/com.eclipsesource.megit.plugin/META-INF/MANIFEST.MF
+++ b/com.eclipsesource.megit.plugin/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Plugin
 Bundle-SymbolicName: com.eclipsesource.megit.plugin;singleton:=true
-Bundle-Version: 0.6.0.qualifier
+Bundle-Version: 0.7.0.qualifier
 Bundle-Activator: com.eclipsesource.megit.plugin.Activator
 Bundle-Vendor: ECLIPSESOURCE
 Require-Bundle: org.eclipse.ui,

--- a/com.eclipsesource.megit.plugin/pom.xml
+++ b/com.eclipsesource.megit.plugin/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.eclipsesource.megit</groupId>
 		<artifactId>com.eclipsesource.megit.parent</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.7.0-SNAPSHOT</version>
 		<relativePath>../com.eclipsesource.megit.parent</relativePath>
 	</parent>
 	<artifactId>com.eclipsesource.megit.plugin</artifactId>

--- a/com.eclipsesource.megit.product/megit.product
+++ b/com.eclipsesource.megit.product/megit.product
@@ -319,6 +319,8 @@ version(s), and exceptions or additional permissions here}.&quot;
       <feature id="org.eclipse.jgit.lfs"/>
       <feature id="org.eclipse.egit"/>
       <feature id="org.eclipse.egit.gitflow.feature"/>
+      <feature id="org.eclipse.tm4e.feature" installMode="root"/>
+      <feature id="org.eclipse.tm4e.language_pack.feature" installMode="root"/>
    </features>
 
    <configurations>

--- a/com.eclipsesource.megit.product/pom.xml
+++ b/com.eclipsesource.megit.product/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.eclipsesource.megit</groupId>
 		<artifactId>com.eclipsesource.megit.parent</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.7.0-SNAPSHOT</version>
 		<relativePath>../com.eclipsesource.megit.parent</relativePath>
 	</parent>
 	<artifactId>com.eclipsesource.megit.product</artifactId>


### PR DESCRIPTION
This also adds the tm4e for generic syntax highlighting.
Fixes https://github.com/eclipsesource/megit/issues/55