### PR TITLE
docs: fix typo 'Miminize' -> 'Minimize' in README changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The runnable product will be available in `com.eclipsesource.megit.product/targe
 - 0.0.1 Initial release based on Eclipse EGit 2020-12
 - 0.0.2 Based on Eclipse EGit 2020-12
   - Git perspective as default and dark theme by default (#7)
-  - Miminize editor area by default and fix of #8 (#9)
+  - Minimize editor area by default and fix of #8 (#9)
 - 0.0.3 Update to Eclipse EGit 2021-03
 - 0.0.4 Update to Eclipse EGit 2021-09
 - 0.1.0 Update to Eclipse EGit 2021-12


### PR DESCRIPTION
This fixes a small typo in the README changelog: `Miminize` -> `Minimize` (in the 0.0.2 entry). Docs-only change, no functional impact.