### PR TITLE
chore: update justj to 21.0.11.v20260515-1531

### DIFF
--- a/com.eclipsesource.megit.parent/megit.target
+++ b/com.eclipsesource.megit.parent/megit.target
@@ -149,7 +149,7 @@
       <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-03"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.justj.openjdk.hotspot.jre.full.feature.group" version="21.0.10.v20260205-0638"/>
+      <unit id="org.eclipse.justj.openjdk.hotspot.jre.full.feature.group" version="21.0.11.v20260515-1531"/>
       <repository location="https://download.eclipse.org/justj/jres/21/updates/release/latest"/>
     </location>
     <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="error" type="Maven" label="extras-megit">


### PR DESCRIPTION
The JustJ release/latest repository no longer serves 21.0.10.v20260205-0638, breaking the CI build with 'Could not find ... in the repositories of the current location'. Bump to the currently published version.